### PR TITLE
fixed bad characters in license text causing crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #
 
 VER_MJR = 1.0
-VER_MNR = 0
+VER_MNR = 1
 RELEASE = 0
 VER	= $(VER_MJR).$(VER_MNR)
 TAR	= fdpr_wrap-$(VER)

--- a/bin/fdpr_dl.py
+++ b/bin/fdpr_dl.py
@@ -3,14 +3,14 @@
 '''
 Copyright (C) 2017 IBM Corporation
 
-Licensed under the Apache License, Version 2.0 (the “License”);
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an “AS IS” BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.

--- a/bin/fdpr_instr
+++ b/bin/fdpr_instr
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_instr_prof
+++ b/bin/fdpr_instr_prof
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_instr_prof_jour
+++ b/bin/fdpr_instr_prof_jour
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_instr_prof_opt
+++ b/bin/fdpr_instr_prof_opt
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_jour
+++ b/bin/fdpr_jour
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_opt
+++ b/bin/fdpr_opt
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_prof
+++ b/bin/fdpr_prof
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_prof_jour
+++ b/bin/fdpr_prof_jour
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/bin/fdpr_prof_opt
+++ b/bin/fdpr_prof_opt
@@ -2,12 +2,12 @@
 
 : '
   Copyright (C) 2017 IBM Corporation
-  Licensed under the Apache License, Version 2.0 (the “License”);
+  Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
   http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an “AS IS” BASIS,
+  distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: fdpr-wrap
-Version: 1.0.0-0
+Version: 1.0.1-0
 Architecture: ppc64el
 Maintainer: Paul A. Clarke <pc@us.ibm.com>
 Section: devel


### PR DESCRIPTION
License text contained backward double quotes instead
of plain double quotes.

  File "/opt/ibm/fdprpro/bin/fdpr_dl.py", line 6
SyntaxError: Non-ASCII character '\xe2' in file /opt/ibm/fdprpro/bin/fdpr_dl.py on line 7, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>