### PR TITLE
fix: 'quiet' is not defined

### DIFF
--- a/bin/fdpr_dl.py
+++ b/bin/fdpr_dl.py
@@ -34,6 +34,8 @@ if not os.path.isfile(fdpr_file):
 
 fdpr_params = ''
 bin_name = ' '
+quiet = False
+
 # read parameters
 try:
       opts, args = getopt.getopt(sys.argv,"hp:a:")
@@ -44,6 +46,8 @@ for opt, arg in opts:
     if opt in ("-h", "--help"):
          print 'fdpr_dl.py <fdpr options> '
          sys.exit()
+    if opt in ("--quiet"):
+	quiet = True
 
 argv_list = list(sys.argv)
 if (len(argv_list) < 2):


### PR DESCRIPTION
```
$ /opt/ibm/fdprpro/bin/fdpr_instr_prof_jour ./load
/opt/ibm/fdprpro/bin/fdpr_dl.py -a instr -p ./load -f ./load.prof -o ./load.instr -w 2 -q
Traceback (most recent call last):
  File "/opt/ibm/fdprpro/bin/fdpr_dl.py", line 142, in <module>
    ExecuteCmd()
  File "/opt/ibm/fdprpro/bin/fdpr_dl.py", line 128, in ExecuteCmd
    if result == 0 and not quiet:
NameError: global name 'quiet' is not defined
```

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>