### PR TITLE
Remove %{?dist} from the spec file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ services:
 
 script:
   - docker build .
-  - ls -la

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: bash
+
+sudo: required
+
+os: 
+ - linux-ppc64le
+
+services:
+  - docker
+
+script:
+  - docker build .
+  - ls -la

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ppc64le/fedora
+RUN yum -y groupinstall "Development Tools"
+RUN yum -y install fedora-packager rpmdevtools alien
+CMD git clone https://github.com/rpsene/fdpr-wrap.git \
+    cd ./fdpr-wrap \
+    make \
+    mkdir ./release \
+    mv ./rpmbuild/RPMS/ppc64le/*.rpm ./release \
+    cd ./release \
+    alien *.rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ CMD git clone https://github.com/rpsene/fdpr-wrap.git \
     mkdir ./release \
     mv ./rpmbuild/RPMS/ppc64le/*.rpm ./release \
     cd ./release \
-    alien *.rpm
+    alien *.rpm \
+    ls -la

--- a/rpm_fdpr_wrap.spec
+++ b/rpm_fdpr_wrap.spec
@@ -15,7 +15,7 @@
 %define _topdir TOPDIR
 Name:		fdpr_wrap
 Version:	MAJOR.MINOR
-Release:	RELEASE%{?dist}
+Release:	RELEASE
 Summary:	FDPR wrapper scripts for the IBM SDK for Linux on Power (IDE and CLI)
 License:	Apache 2.0
 URL:		http://www.haifa.il.ibm.com/projects/systems/cot/fdpr/fdpr_linux.html


### PR DESCRIPTION
Remove %{?dist} from the spec file given that the same version of FDPR works across multiple rpm based systems. With this change the name of the package will be fdpr_wrap-1.0.2-0.ppc64le.rpm instead of fdpr_wrap-1.0.2-0.fc28.ppc64le.rpm